### PR TITLE
Make the tutorial link of program optional

### DIFF
--- a/client/templates/programs/program-page.html
+++ b/client/templates/programs/program-page.html
@@ -12,7 +12,7 @@
           <input class="form-control" id="program-submit-tags" value="{{tags}}"/>
         </div>
         <div class="form-group">
-          <label>Tutorial Link</label>
+          <label>Tunk<small>(optional)</small></label>
           <input class="form-control" id="program-submit-tutorial-link" value="{{tutorialLink}}"/>
         </div>
         <div class="form-group">

--- a/client/templates/programs/program-submit.html
+++ b/client/templates/programs/program-submit.html
@@ -13,7 +13,7 @@
           <input class="form-control" id="program-submit-tags"/>
         </div>
         <div class="form-group">
-          <label>Tutorial Link</label>
+          <label>Tutorial Link <small>(optional)</small></label>
           <input class="form-control" id="program-submit-tutorial-link"/>
           <div id="tutLinkError">
           </div>


### PR DESCRIPTION
Since the tutorial link of activity is optional, to avoid ambiguity, add (optional) to tutorial link for program.