### PR TITLE
Changes the FAQ into a tutorial setup

### DIFF
--- a/client/templates/application/layout.html
+++ b/client/templates/application/layout.html
@@ -37,7 +37,7 @@
             {{/if}}
           </ul>
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="{{ pathFor 'faq' }}">FAQs</a></li>
+            <li><a href="{{ pathFor 'faq' }}">Tutorial</a></li>
             {{#if currentUser}}
               <!--<li class="search">
                 <form class="navbar-form navbar-right" role="search">

--- a/client/templates/general/faq.html
+++ b/client/templates/general/faq.html
@@ -38,7 +38,7 @@
 			</p>
 		</div>
 		<div class="Question-header">
-           <a name="video 1">2. Video 2 <!--insert video title here--></a>
+           <a name="video 2">2. Video 2 <!--insert video title here--></a>
         </div>
   	    <div class="Question-response">
 			<!--Youtube video -> share -> embed, copy and paste the result between here. Use 640x360 size.-->
@@ -51,7 +51,7 @@
 			</p>
 		</div>
 		<div class="Question-header">
-           <a name="video 1">3. video 3 <!--insert video title here--></a>
+           <a name="video 3">3. Video 3 <!--insert video title here--></a>
         </div>
   	    <div class="Question-response">
 			<!--Youtube video -> share -> embed, copy and paste the result between here. Use 640x360 size.-->

--- a/client/templates/general/faq.html
+++ b/client/templates/general/faq.html
@@ -22,11 +22,13 @@
 
         </div>
   	     <div class="Question-header">
-           <a name="purpose">1) What is the purpose of this website?</a>
+           <a name="purpose">1) Tutorial Video For Test <!--insert video title here--></a>
          </div>
   	     <div class="Question-response">
-           <li>This website is used for Westminster to store and share programs and their constituent activities with other retirement communities. This website also gives people the ability to create and upload their own activities and programs to share with others, acting as an online database for all parties involved.</li>
-         </div>
+			<!--Youtube video -> share -> embed, copy and paste the result between here-->
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/wzh0EuLhRhE" frameborder="0" allowfullscreen></iframe>
+			<!--and here-->
+		</div>
     	   <div class="Question-header">
            <a name="activity">2) What is an activity?</a>
          </div>

--- a/client/templates/general/faq.html
+++ b/client/templates/general/faq.html
@@ -5,7 +5,7 @@
   <div class="page page-faq container">
     <div class="login-wrapper">
       <div class="FAQ-background">
-        <h1 id="FAQ-header">Welcome to the FAQ Page!</h1>
+        <h1 id="FAQ-header">Welcome to the Tutorial Page!</h1>
       
         <div class="Content-Table">
           <h1 id="TOC-header">Table of Contents</h1>

--- a/client/templates/general/faq.html
+++ b/client/templates/general/faq.html
@@ -25,8 +25,8 @@
            <a name="purpose">1) Tutorial Video For Test <!--insert video title here--></a>
          </div>
   	     <div class="Question-response">
-			<!--Youtube video -> share -> embed, copy and paste the result between here-->
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/wzh0EuLhRhE" frameborder="0" allowfullscreen></iframe>
+			<!--Youtube video -> share -> embed, copy and paste the result between here. Use 640x360 size.-->
+<iframe width="640" height="360" src="https://www.youtube.com/embed/wzh0EuLhRhE" frameborder="0" allowfullscreen></iframe>
 			<!--and here-->
 		</div>
     	   <div class="Question-header">

--- a/client/templates/general/faq.html
+++ b/client/templates/general/faq.html
@@ -10,37 +10,61 @@
         <div class="Content-Table">
           <h1 id="TOC-header">Table of Contents</h1>
           <div class="Table-item">
-            <a href="#purpose">What is the purpose of this website?</a>
+            <a href="#video 1">What is the purpose of this website?</a>
           </div>
           <div class="Table-item">
-            <a href="#activity">What is an activity?</a>
+            <a href="#video 2">What is an activity?</a>
           </div>
           <div class="Table-item">
-            <a href="#program">What is a program?</a>
+            <a href="#video 3">What is a program?</a>
           </div>
-
-
+		
+		
         </div>
-  	     <div class="Question-header">
-           <a name="purpose">1) Tutorial Video For Test <!--insert video title here--></a>
-         </div>
-  	     <div class="Question-response">
+		<div class="Question-header">
+           <a name="video 1">1) Tutorial Video For Test <!--insert video title here--></a>
+        </div>
+  	    <div class="Question-response">
 			<!--Youtube video -> share -> embed, copy and paste the result between here. Use 640x360 size.-->
-<iframe width="640" height="360" src="https://www.youtube.com/embed/wzh0EuLhRhE" frameborder="0" allowfullscreen></iframe>
+				<iframe width="640" height="360" src="https://www.youtube.com/embed/wzh0EuLhRhE" frameborder="0" allowfullscreen></iframe>
 			<!--and here-->
 		</div>
-    	   <div class="Question-header">
-           <a name="activity">2) What is an activity?</a>
-         </div>
-    	   <div class="Question-response">
-           <li>An activity is an activity that lasts a short time and tests a specific aspect or aspects of the brain. The properties of an activity include a title, description, duration, possible tags that describe key points of the activity, and a document link.</li>
-         </div>
-    	   <div class="Question-header">
-           <a name="program">3) What is a program?</a>
-         </div>
-    	   <div class="Question-response">
-          <li>A program is a collection of activities that can be customized with all available activities in the database. Anyone with proper access can either download programs or customize their own from available activities. These programs vary in time from all of the activities it consists of.</li>
+		<div class="Video-note">
+			<p>
+			<!--If more detailed description than the title provides is required in text, place it here.-->
+			Lorem ipsum dolor sit amet, consetetur sadipscing elitr,  sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+			Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
+			</p>
+		</div>
+		<div class="Question-header">
+           <a name="video 1">2. Video 2 <!--insert video title here--></a>
         </div>
+  	    <div class="Question-response">
+			<!--Youtube video -> share -> embed, copy and paste the result between here. Use 640x360 size.-->
+				<iframe width="640" height="360" src="https://www.youtube.com/embed/wzh0EuLhRhE" frameborder="0" allowfullscreen></iframe>
+			<!--and here-->
+		</div>
+		<div class="Video-note">
+			<p>
+			<!--If more detailed description than the title provides is required in text, place it here.-->
+			</p>
+		</div>
+		<div class="Question-header">
+           <a name="video 1">3. video 3 <!--insert video title here--></a>
+        </div>
+  	    <div class="Question-response">
+			<!--Youtube video -> share -> embed, copy and paste the result between here. Use 640x360 size.-->
+				<iframe width="640" height="360" src="https://www.youtube.com/embed/wzh0EuLhRhE" frameborder="0" allowfullscreen></iframe>
+			<!--and here-->
+		</div>
+		<div class="Video-note">
+			<p>
+			<!--If more detailed description than the title provides is required in text, place it here.-->
+			</p>
+		</div>
+
+			<!-- Add more videos in similar format here if more videos are required.-->
       </div>
     </div>
   </div>

--- a/client/templates/general/faq.less
+++ b/client/templates/general/faq.less
@@ -22,6 +22,15 @@
 	font-size: 18px;
 }
 
+.Video-note{
+	color: rgb(0,0,90);
+	text-align: left;
+	padding-left: 90px;
+	font-size: 16px;
+	padding-top: 20 px;
+	padding-right:200px;
+}
+
 .FAQ-background {
 	background-color: #fff;
 	margin: 80px;


### PR DESCRIPTION
This changes the FAQ to a place where tutorial videos can be linked. The Table of Contents feature is kept, and each video has a place for a title above it and additional text below it.

Before:
![faq before](https://user-images.githubusercontent.com/9277422/28157290-0223240a-6784-11e7-92cc-ff800053b20f.JPG)
After:
![tutorial after 1](https://user-images.githubusercontent.com/9277422/28157301-0acd597c-6784-11e7-9924-38dc6cd303a6.JPG)
![tutorial after 2](https://user-images.githubusercontent.com/9277422/28157306-0d81289c-6784-11e7-81d6-736173d0acf1.JPG)


