### PR TITLE
Fixes a mis-titled ID

### DIFF
--- a/client/templates/activities/activity-list.js
+++ b/client/templates/activities/activity-list.js
@@ -44,7 +44,7 @@ Template.activityList.events({
       "Planning/Judgement": $("#Planning-filter").is(':checked'),
       "Computation": $("#Computation-filter").is(':checked'),
       "Working Memory": $("#Working-filter").is(':checked'),
-      "Long Term Memory": $("#Longtermfilter").is(':checked'),
+      "Long Term Memory": $("#Longterm-filter").is(':checked'),
       "Emotional Memory": $("#Emotional-filter").is(':checked'),
     };
     // Reset active filter list.

--- a/client/templates/programs/program-list.js
+++ b/client/templates/programs/program-list.js
@@ -45,7 +45,7 @@ Template.programList.events({
       "Planning/Judgement": $("#Planning-filter").is(':checked'),
       "Computation": $("#Computation-filter").is(':checked'),
       "Working Memory": $("#Working-filter").is(':checked'),
-      "Long Term Memory": $("#Longtermfilter").is(':checked'),
+      "Long Term Memory": $("#Longterm-filter").is(':checked'),
       "Emotional Memory": $("#Emotional-filter").is(':checked'),
     };
     // Reset active filter list.


### PR DESCRIPTION
The ID in the page's respective html is Longterm-filter. It's written in the code as Longtermfilter. This causes the brainTarget filter not to work. This changes the ID to Longterm-filter in both the program and activity code.